### PR TITLE
fix(prism): apply syntax highlighting to dynamically created code elements

### DIFF
--- a/index.js
+++ b/index.js
@@ -67,6 +67,9 @@ function createLiSection(obj, sectionId, h3Text) {
 
     languageListItems(obj, lang, h3Text, section, grid, secondaryChild);
   })
+
+  // Re-apply Prism.js highlighting only to this section
+  Prism.highlightAllUnder(section);
 }
 
 // HELPER function: used in createLiSection
@@ -87,7 +90,7 @@ function languageListItems(obj, string, text, el1, el2, el3) {
   obj[string].forEach(item => {
     const li = document.createElement('li');
     const code = document.createElement('code');
-    code.className = `custom-${string.toLowerCase()}`;
+    code.className = `language-${string.toLowerCase()}`;
     code.textContent = item;
     li.append(code);
     list.append(li);


### PR DESCRIPTION
## Summary

Fixes #8 - Prism.js styles not applying on form submit.

When users change secondary languages and click Compare, the syntax highlighting styles were not applied until page reload.

## Changes

- Changed code element classes from `custom-${lang}` to `language-${lang}` to match Prism.js expected pattern
- Added `Prism.highlightAllUnder(section)` in `createLiSection()` to apply highlighting to dynamically created elements
- Optimized to apply highlighting only to specific sections instead of re-highlighting the entire page

## Technical Details

The fix addresses two issues:
1. Prism.js only recognizes classes matching the pattern `language-xxxx`, not `custom-xxxx`
2. Prism.highlightAll() was not being called after dynamic element creation

By using `Prism.highlightAllUnder(section)` within `createLiSection()`, highlighting is applied efficiently to newly created elements only, improving performance.

Closes #8